### PR TITLE
Fix capitalization and add better window manager detection.

### DIFF
--- a/fetch.sh
+++ b/fetch.sh
@@ -148,10 +148,19 @@ shell="$SHELL"
 # This can be detected without wmctrl by using an array of window manager
 # process names and pgrep but it's really slow.
 # (Doubles script startup time in some cases).
-# If you don't want to install wmctrl you can either edit the var below
+# If you don't want to install wmctrl you can either edit the var below,
+# export the "windowmanager" variable in your shell's configuration file,
 # or run the script with: --windowmanager wmname
 # windowmanager="openbox"
-windowmanager=$(wmctrl -m | awk '/Name:/ {printf $2}')
+if [ -z $windowmanager ]; then
+    if type -p wmctrl >/dev/null 2>&1; then
+        windowmanager=$(wmctrl -m | awk '/Name:/ {printf $2}')
+    elif [ -e ~/.xinitrc ]; then
+        windowmanager=$(grep -v "^#" "${HOME}/.xinitrc" | tail -n 1 | cut -d " " -f2)
+    else
+        windowmanager="Unknown"
+    fi
+fi
 
 # Processor (Configurable with "-C", "-S" and "--cpu", "--speed" at launch)
 cpu="$(awk 'BEGIN{FS=":"} /model name/ {print $2; exit}' /proc/cpuinfo |\

--- a/fetch.sh
+++ b/fetch.sh
@@ -23,7 +23,7 @@ title_uptime="Uptime"
 title_packages="Packages"
 title_shell="Shell"
 title_windowmanager="Window Manager"
-title_cpu="Cpu"
+title_cpu="CPU"
 title_memory="Memory"
 title_song="Song"
 


### PR DESCRIPTION
Summary of the WM madness going on here:

If the user has not exported the environment var `windowmanager` (in which case there is no need to overwrite it temporarily, it's already defined), then the script checks if `wmctrl` is installed. If not, it checks if `.xinitrc` exists. If it does, it greps the exec line. Otherwise, it gives up.